### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/PlayerStats/PlayerStats.php
+++ b/src/PlayerStats/PlayerStats.php
@@ -64,6 +64,7 @@ class PlayerStats extends PluginBase implements Listener{
         $this->getServer()->getLogger()->info("Creating query to database...");
         $resource = $this->getResource("mysql.sql");
         $this->db->query(stream_get_contents($resource));
+        @fclose($resource);
         $this->getServer()->getLogger()->info("Done!");
         $this->getServer()->getLogger()->info("Successfully connected to MySQL server!");
     }


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
